### PR TITLE
fix consul bind multiple IPs issue in Mac OSX

### DIFF
--- a/consul.go
+++ b/consul.go
@@ -104,7 +104,7 @@ func (s *consulService) Start() (port int, err error) {
 		return 0, fmt.Errorf("Fail to write config file(path: %v): %v", configFile, err)
 	}
 	s.cmd = exec.Command(
-		"consul", "agent", "-config-file", configFile,
+		"consul", "agent", "-bind", "127.0.0.1", "-config-file", configFile,
 	)
 	if err := s.cmd.Start(); err != nil {
 		return 0, fmt.Errorf("Fail to start consul: %v", err)


### PR DESCRIPTION
Start consul in Mac OSX will face the following issue:
`Failed to get advertise address: Multiple private IPs found. Please configure one.`

Therefore, I specifically provide the local IP to make it start successfully.
